### PR TITLE
Generate a number guessing game

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,4 @@ authors = ["Jettro Coenradie <jettro.coenradie@luminis.eu>"]
 edition = "2021"
 
 [dependencies]
+rand = "0.8.4"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,34 @@
+use rand::Rng;
+use std::io;
+
 fn main() {
-    println!("Hello, world!");
+    let secret_number = rand::thread_rng().gen_range(1..=100);
+
+    println!("Guess the number!");
+
+    loop {
+        println!("Please input your guess.");
+
+        let mut guess = String::new();
+
+        io::stdin()
+            .read_line(&mut guess)
+            .expect("Failed to read line");
+
+        let guess: u32 = match guess.trim().parse() {
+            Ok(num) => num,
+            Err(_) => continue,
+        };
+
+        println!("You guessed: {}", guess);
+
+        match guess.cmp(&secret_number) {
+            std::cmp::Ordering::Less => println!("Too small!"),
+            std::cmp::Ordering::Greater => println!("Too big!"),
+            std::cmp::Ordering::Equal => {
+                println!("You win!");
+                break;
+            }
+        }
+    }
 }


### PR DESCRIPTION
Fixes #5

adds the first version of the number guessing game

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jettroluminis/co-write-code/pull/6?shareId=a85f73ba-2052-4314-b2ea-dc69f058cfec).